### PR TITLE
fix(ui): drop unnecessary semicolon from div class

### DIFF
--- a/app.jl.html
+++ b/app.jl.html
@@ -302,7 +302,7 @@
                         glossy :label="total_score" />
                 </div>
             </div>
-            <div class="row justify-center" style="margin-top: 5pt" ;>
+            <div class="row justify-center" style="margin-top: 5pt;">
                 <q-btn
                     style="font-size: large; height: 60px; width: 200px; background-color: white; border: 2px solid rgb(160, 218, 170);"
                     glossy label="Play again" v-on:click="restartapp = true">


### PR DESCRIPTION
This PR removes an accidentally added semicolon after the style attribute in a `<div>`.

The stray semicolon made the HTML invalid, which caused rendering issues. Removing it restores expected behavior.